### PR TITLE
Basic root implementation

### DIFF
--- a/outpack/__init__.py
+++ b/outpack/__init__.py
@@ -1,1 +1,4 @@
+from .root import outpack_init
+
+
 __version__ = '0.1.0'

--- a/outpack/config.py
+++ b/outpack/config.py
@@ -1,0 +1,75 @@
+import os.path
+
+from dataclasses import dataclass, field
+from dataclasses_json import config, dataclass_json, LetterCase
+from typing import Dict, Optional
+
+
+# Elsewhere eventually, once we get sorted with validation.
+def outpack_schema_version():
+    return "0.0.1"
+
+
+def config_new(path_archive, use_file_store):
+    return Config(outpack_schema_version(),
+                  ConfigCore("sha256", path_archive, use_file_store),
+                  {})
+
+
+def config_serialise(config):
+    # TODO: validate here too
+    return config.to_json()
+
+
+def config_write(config, root_path):
+    with open(_config_path(root_path), "w") as f:
+        f.write(config_serialise(config) + "\n")
+
+
+def config_read(root_path):
+    with open(_config_path(root_path), "r") as f:
+        s = f.read()
+    return Config.from_json(s.strip())
+
+
+@dataclass_json()
+@dataclass
+class ConfigCore:
+    hash_algorithm: str
+    path_archive: Optional[str]
+    use_file_store: bool
+
+    def __post_init__(self):
+        if self.path_archive is None and not self.use_file_store:
+            raise Exception("invalid path_archive")
+
+
+@dataclass_json
+@dataclass
+class Location:
+    name: str
+    type: str
+    path: str
+
+
+def _encode_location_dict(d):
+    return [x.to_dict() for x in d.values()]
+
+
+def _decode_location_dict(d):
+    return {x["name"]: Location.from_dict(x) for x in d}
+
+
+def _config_path(root_path):
+    return os.path.join(root_path, ".outpack", "config.json")
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass
+class Config:
+    schema_version: str
+    core: ConfigCore
+    location: Dict[str, Location] = field(
+        metadata=config(
+            encoder=_encode_location_dict,
+            decoder=_decode_location_dict))

--- a/outpack/root.py
+++ b/outpack/root.py
@@ -1,0 +1,43 @@
+import os
+import os.path
+
+from .config import config_new, config_read, config_write
+from .util import find_file_descend
+
+
+def outpack_init(root, path_archive="archive", use_file_store=False):
+    path_outpack = os.path.join(root, ".outpack")
+    if os.path.exists(path_outpack):
+        raise Exception(f"outpack already initialised at '{root}'")
+
+    config = config_new(path_archive, use_file_store)
+    os.makedirs(path_outpack)
+    os.makedirs(os.path.join(path_outpack, "metadata"))
+    os.makedirs(os.path.join(path_outpack, "location"))
+    config_write(config, root)
+
+
+def root_open(path):
+    if type(path) == Root:
+        return path
+    if not os.path.exists(os.path.join(path, ".outpack")):
+        raise Exception(f"'{path}' does not look like an outpack root")
+    return Root(path)
+
+
+def root_locate(path):
+    if type(path) == Root:
+        return path
+    if path is None:
+        path = "."
+    path_found = find_file_descend(".outpack", path)
+    if path_found is None:
+        raise Exception("Did not find existing outpack root from " +
+                        f"directory '{path}'")
+    return Root(path_found)
+
+
+class Root:
+    def __init__(self, path):
+        self.path = path
+        self.config = config_read(path)

--- a/outpack/util.py
+++ b/outpack/util.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def find_file_descend(filename, path):
+    path = Path(path)
+    root = Path(path.root)
+
+    while path != root:
+        attempt = path / filename
+        if attempt.exists():
+            return str(attempt.parent)
+        path = path.parent
+
+    return None

--- a/poetry.lock
+++ b/poetry.lock
@@ -43,6 +43,50 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["tomli"]
 
 [[package]]
+name = "dataclasses-json"
+version = "0.5.7"
+description = "Easily serialize dataclasses to and from JSON"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+marshmallow = ">=3.3.0,<4.0.0"
+marshmallow-enum = ">=1.5.1,<2.0.0"
+typing-inspect = ">=0.4.0"
+
+[package.extras]
+dev = ["pytest (>=6.2.3)", "ipython", "mypy (>=0.710)", "hypothesis", "portray", "flake8", "simplejson", "types-dataclasses"]
+
+[[package]]
+name = "marshmallow"
+version = "3.15.0"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+dev = ["pytest", "pytz", "simplejson", "mypy (==0.940)", "flake8 (==4.0.1)", "flake8-bugbear (==22.1.11)", "pre-commit (>=2.4,<3.0)", "tox"]
+docs = ["sphinx (==4.4.0)", "sphinx-issues (==3.0.1)", "alabaster (==0.7.12)", "sphinx-version-warning (==1.1.2)", "autodocsumm (==0.2.7)"]
+lint = ["mypy (==0.940)", "flake8 (==4.0.1)", "flake8-bugbear (==22.1.11)", "pre-commit (>=2.4,<3.0)"]
+tests = ["pytest", "pytz", "simplejson"]
+
+[[package]]
+name = "marshmallow-enum"
+version = "1.5.1"
+description = "Enum field for Marshmallow"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+marshmallow = ">=2.0.0"
+
+[[package]]
 name = "more-itertools"
 version = "8.12.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -51,10 +95,18 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -92,7 +144,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pyparsing"
 version = "3.0.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -145,6 +197,26 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-inspect"
+version = "0.7.1"
+description = "Runtime inspection utilities for typing module."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -155,7 +227,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7414dc5c80db0e5ecee46ac7058d2c74dddc32c836c9e8639884cfd751e0b0a4"
+content-hash = "28b448b541ff6d9014024208527881f505641583210abdb182c402a4aadfa2c6"
 
 [metadata.files]
 atomicwrites = [
@@ -213,9 +285,25 @@ coverage = [
     {file = "coverage-6.3.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:18d520c6860515a771708937d2f78f63cc47ab3b80cb78e86573b0a760161faf"},
     {file = "coverage-6.3.2.tar.gz", hash = "sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9"},
 ]
+dataclasses-json = [
+    {file = "dataclasses-json-0.5.7.tar.gz", hash = "sha256:c2c11bc8214fbf709ffc369d11446ff6945254a7f09128154a7620613d8fda90"},
+    {file = "dataclasses_json-0.5.7-py3-none-any.whl", hash = "sha256:bc285b5f892094c3a53d558858a88553dd6a61a11ab1a8128a0e554385dcc5dd"},
+]
+marshmallow = [
+    {file = "marshmallow-3.15.0-py3-none-any.whl", hash = "sha256:ff79885ed43b579782f48c251d262e062bce49c65c52412458769a4fb57ac30f"},
+    {file = "marshmallow-3.15.0.tar.gz", hash = "sha256:2aaaab4f01ef4f5a011a21319af9fce17ab13bf28a026d1252adab0e035648d5"},
+]
+marshmallow-enum = [
+    {file = "marshmallow-enum-1.5.1.tar.gz", hash = "sha256:38e697e11f45a8e64b4a1e664000897c659b60aa57bfa18d44e226a9920b6e58"},
+    {file = "marshmallow_enum-1.5.1-py2.py3-none-any.whl", hash = "sha256:57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072"},
+]
 more-itertools = [
     {file = "more-itertools-8.12.0.tar.gz", hash = "sha256:7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064"},
     {file = "more_itertools-8.12.0-py3-none-any.whl", hash = "sha256:43e6dd9942dffd72661a2c4ef383ad7da1e6a3e968a927ad7a6083ab410a688b"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -248,6 +336,15 @@ pytest-cov = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.7.1-py2-none-any.whl", hash = "sha256:b1f56c0783ef0f25fb064a01be6e5407e54cf4a4bf4f3ba3fe51e0bd6dcea9e5"},
+    {file = "typing_inspect-0.7.1-py3-none-any.whl", hash = "sha256:3cd7d4563e997719a710a3bfe7ffb544c6b72069b6812a02e9b414a8fa3aaa6b"},
+    {file = "typing_inspect-0.7.1.tar.gz", hash = "sha256:047d4097d9b17f46531bf6f014356111a1b6fb821a24fe7ac909853ca2a782aa"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/mrc-ide/outpack-py"
 
 [tool.poetry.dependencies]
 python = "^3.8"
+dataclasses-json = "^0.5.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
@@ -19,3 +20,9 @@ pytest-cov = "^3.0.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.coverage.run]
+omit = [".*", "*/site-packages/*"]
+
+[tool.coverage.report]
+fail_under = 100

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,38 @@
+import json
+import pytest
+
+from outpack.config import *
+
+
+def test_create_empty_config():
+    cfg = config_new("archive", False)
+    assert type(cfg) == Config
+    assert cfg.schema_version == outpack_schema_version()
+    assert cfg.core.path_archive == "archive"
+    assert not cfg.core.use_file_store
+    assert cfg.core.hash_algorithm == "sha256"
+    assert cfg.location == {}
+
+
+def test_must_use_some_storage():
+    with pytest.raises(Exception) as e:
+        config_new(None, False)
+    assert e.match("invalid path_archive")
+
+
+def test_can_serialise_config():
+    cfg = config_new("archive", True)
+    s = config_serialise(cfg)
+    assert type(s) == str
+    assert Config.from_json(s) == cfg
+
+
+def test_can_serialise_locations_as_list():
+    cfg = config_new("archive", True)
+    cfg.location["src"] = Location("src", "file", "/path/to/file")
+    s = config_serialise(cfg)
+    d = json.loads(s)
+    assert type(d["location"]) == list
+    assert d["location"][0] == \
+        {"name": "src", "type": "file", "path": "/path/to/file"}
+    assert Config.from_json(s) == cfg

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,50 @@
+import pytest
+import os.path
+from outpack.root import *
+import outpack.config
+
+
+def test_create_new_root(tmp_path):
+    outpack_init(tmp_path)
+    assert os.path.exists(tmp_path)
+    assert os.path.exists(os.path.join(tmp_path, ".outpack"))
+    root = root_open(tmp_path)
+    assert type(root) == Root
+    assert root.config == outpack.config.config_new("archive", False)
+
+
+def test_error_if_root_not_present_when_opening(tmp_path):
+    with pytest.raises(Exception) as e:
+        root_open(str(tmp_path))
+    assert e.match("'.+' does not look like an outpack root")
+
+
+def test_error_if_root_not_present_when_locating(tmp_path):
+    with pytest.raises(Exception) as e:
+        root_locate(None)
+    assert e.match("Did not find existing outpack root from directory '.'")
+
+
+def test_locate_root_from_subdir(tmp_path):
+    outpack_init(tmp_path)
+    sub = tmp_path / "sub" / "directory"
+    sub.mkdir(parents=True)
+    a = root_locate(sub)
+    b = root_open(str(tmp_path))
+    assert a.path == b.path
+    assert a.config == b.config
+
+
+def test_no_double_initialisation(tmp_path):
+    p = str(tmp_path)
+    outpack_init(p)
+    with pytest.raises(Exception) as e:
+        outpack_init(p)
+    assert e.match("outpack already initialised at '.+'")
+
+
+def test_opening_root_object_returns_it(tmp_path):
+    outpack_init(tmp_path)
+    r = root_open(tmp_path)
+    assert root_open(r) == r
+    assert root_locate(r) == r

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,11 @@
+import os
+
+from outpack.util import find_file_descend
+
+
+def test_find_descend(tmp_path):
+    (tmp_path / "a" / "b" / "c" / "d").mkdir(parents=True)
+    (tmp_path / "a" / "b" / ".foo").mkdir(parents=True)
+    assert find_file_descend(".foo", tmp_path / "a/b/c/d") == \
+        str(tmp_path / "a/b")
+    assert find_file_descend(".foo", tmp_path / "a") is None


### PR DESCRIPTION
Implements the minimum to support creating and opening a root, including configuration (validating, serialising and deserialising) and the same logic around opening and locating the root as the R version.

This does not include jsonschema validation yet; that actually looks a bit annoying to do, but we will need to sort that out at some point.